### PR TITLE
Fix golang.org/x/net CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}
 RUN git fetch --all --tags --prune && \
     git checkout tags/${TAG} -b ${TAG}
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 RUN go mod download
 # cross-compilation setup
 ARG TARGETARCH

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,6 @@
+# golang.org/x/net: CVE-2026-25681, CVE-2026-27136 (net/html XSS), CVE-2026-39821 (net/idna punycode), CVE-2026-25680, CVE-2026-42502, CVE-2026-42506 (net/html DoS & XSS).
+# Drop once upstream requires golang.org/x/net >= v0.55.0.
+-replace golang.org/x/net=golang.org/x/net@v0.55.0
+# golang.org/x/sys: CVE-2026-39824 (net/windows integer overflow in NewNTUnicodeString).
+# Drop once upstream requires golang.org/x/sys >= v0.44.0.
+-replace golang.org/x/sys=golang.org/x/sys@v0.44.0


### PR DESCRIPTION
## Problem

The `hardened-multus-dynamic-networks-controller` image ships HIGH/MEDIUM `golang.org/x/net` and `golang.org/x/sys` CVEs not yet fixed in the pinned upstream release:

- **golang.org/x/net** (fixed in v0.55.0): CVE-2026-25681, CVE-2026-27136, CVE-2026-39821, CVE-2026-25680, CVE-2026-42502, CVE-2026-42506
- **golang.org/x/sys** (fixed in v0.44.0): CVE-2026-39824

## Fix

- Add a repo-root `go-mod-overrides` file pinning the affected modules. Each entry references the CVE(s) so it can be dropped once upstream catches up.
- Wire the Dockerfile `multus-builder` stage to run the shared `go-mod-overrides.sh` so the pin is applied before the binary is built.

## Note

`go-mod-overrides.sh` must be present in the `hardened-build-base` tag referenced by `GO_IMAGE`. Bump `GO_IMAGE` to a tag that ships the script if the current one does not.

CVE source: trivy scan of `rancher/hardened-multus-dynamic-networks-controller:v0.3.8-build20260709`.