### PR TITLE
Add google.golang.org/grpc go.mod override for GHSA-hrxh-6v49-42gf

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -7,3 +7,6 @@
 # golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
 # Drop once upstream requires golang.org/x/text >= v0.39.0.
 -replace golang.org/x/text=golang.org/x/text@v0.39.0
+# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
+# Drop once upstream requires google.golang.org/grpc >= v1.82.1.
+-replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1


### PR DESCRIPTION
Adds a `go-mod-overrides` entry to force `google.golang.org/grpc` to `v1.82.1`, mitigating GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).

Upstream `multus-dynamic-networks-controller` (v0.3.8) requires `google.golang.org/grpc v1.80.0`, which is affected. The override is dropped once upstream requires `>= v1.82.1`.

Mirrors rancher/image-build-multus#182.